### PR TITLE
Enhance R-APDU output readability

### DIFF
--- a/src/apdu/rapdu.rs
+++ b/src/apdu/rapdu.rs
@@ -1,14 +1,26 @@
 use crate::utils::extension::Extendable;
+use crate::tlv::parser::TLV;
+use std::fmt;
 
 #[derive(Debug)]
 pub struct RAPDU {
     pub status: Status,
-    pub data: Vec<u8>,
+    pub raw: Vec<u8>,
+    pub data: Vec<TLV>
 }
 
 impl RAPDU {
     pub fn new(status: Status, data: &[u8]) -> RAPDU {
-        RAPDU { status, data: Vec::from(data) }
+        RAPDU { status, raw: Vec::from(data), data: TLV::decode(Vec::from(data)),  }
+    }
+}
+
+impl fmt::Display for RAPDU {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let raw_str: Vec<String> = self.raw.iter().map(|a| format!("{:02X}", a)).collect();
+        let data_str: Vec<String> = self.data.iter().map(|a| format!("{}", a)).collect();
+
+        write!(f, "R-APDU: {:?}\n  Raw: 0x{}\n  Data: [\n{}  ]\n", self.status, raw_str.join(""), data_str.join(""))
     }
 }
 

--- a/src/connection/usb.rs
+++ b/src/connection/usb.rs
@@ -18,7 +18,7 @@ pub fn transmit(card: &Card, apdu: &APDU) -> Result<RAPDU, &'static str> {
             else {
                 rapdu = RAPDU::new(Status::new(response[length - 2], response[length - 1]), &response[0..length - 2]);
             }
-            println!("R-APDU: {:02X?}", rapdu);
+            println!("{}", rapdu);
             Ok(rapdu)
         }
         Err(err) => {

--- a/src/tlv/parser.rs
+++ b/src/tlv/parser.rs
@@ -1,4 +1,5 @@
 use crate::utils::extension::Extendable;
+use std::fmt;
 
 #[derive(Debug)]
 pub enum Tag {
@@ -107,6 +108,7 @@ pub struct TLV {
 
 impl TLV {
     pub fn parse(data: Vec<u8>) -> Result<(TLV, Vec<u8>), &'static str> {
+
         if data.len() < 2 {
             return Err("Not enough data to parse TLV!");
         }
@@ -129,15 +131,25 @@ impl TLV {
         let mut result: Vec<TLV> = Vec::new();
         let mut data = data;
 
-        loop {
-            let (tlv, remainder) = TLV::parse(data).unwrap();
-            if !tlv.tag.is_template() {
-                result.push(tlv);
-                if remainder.len() == 0 {
-                    break;
-                } else { data = remainder; }
-            } else { data = tlv.value; }
+        if data.len() > 0 {
+            loop {
+                let (tlv, remainder) = TLV::parse(data).unwrap();
+                if !tlv.tag.is_template() {
+                    result.push(tlv);
+                    if remainder.len() == 0 {
+                        break;
+                    } else { data = remainder; }
+                } else { data = tlv.value; }
+            }
         }
         result
+    }
+}
+
+impl fmt::Display for TLV {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let raw_str: Vec<String> = self.value.iter().map(|a| format!("{:02X}", a)).collect();
+        let value_char: Vec<String> = self.value.iter().map(|a| format!("{}", *a as char)).collect();
+        write!(f, "   > {:?} ({}) = 0x{} | {}\n", self.tag, self.length, raw_str.join(""), value_char.join(""))
     }
 }


### PR DESCRIPTION
Improve R-APDU output by parsing the TLV elements from the response:

```
> select A0000000043060

C-APDU: SELECT: [00, A4, 04, 00, 07, A0, 00, 00, 00, 04, 30, 60]
R-APDU: ResponseAvailable { length: 78 }
  Raw: 0x
  Data: [
  ]


C-APDU: GET RESPONSE: [00, C0, 00, 00, 4E]
R-APDU: Ok
  Raw: 0x6F4C8407A0000000043060A54150074D61657374726F8701025F2D067074656E65739F1101019F120D44656269746F204E7562616E6BBF0C159F5D030100009F4D020B0A9F6E0700760000303000
  Data: [
   > DedicatedFileName (7) = 0xA0000000043060 |  0`
   > ApplicationLabel (7) = 0x4D61657374726F | Maestro
   > ApplicationPriorityIndicator (1) = 0x02 |
   > LanguagePreference (6) = 0x7074656E6573 | ptenes
   > IssuerCodeTableIndex (1) = 0x01 |
   > ApplicationPreferredName (13) = 0x44656269746F204E7562616E6B | Debito Nubank
   > UnknownTag (3) = 0x010000 |
   > LogEntry (2) = 0x0B0A |
   > UnknownTag (7) = 0x00760000303000 | v00
  ]
```